### PR TITLE
Story 04 - Support to display price before taxes and fees

### DIFF
--- a/app/src/androidTest/java/com/huynd/skyobserver/activities/MainActivityAndroidTest.java
+++ b/app/src/androidTest/java/com/huynd/skyobserver/activities/MainActivityAndroidTest.java
@@ -44,13 +44,16 @@ public class MainActivityAndroidTest {
 
     @Test
     public void testNavigationDrawer() throws Exception {
+        String[] navigationDrawerItemTitles = mActivity.getResources()
+                .getStringArray(R.array.array_of_navigation_drawer_item_title);
+
         onView(withContentDescription(mActivity.getString(R.string.drawer_open))).perform(click());
         onView(withId(R.id.layout_drawer)).check(matches(isDisplayed()));
         onView(allOf(isAssignableFrom(TextView.class), withParent(isAssignableFrom(Toolbar.class))))
-                .check(matches(withText("Price per day")));
+                .check(matches(withText(navigationDrawerItemTitles[0])));
 
         onData(anything()).inAdapterView(withId(R.id.listview_left_drawer)).atPosition(1).perform(click());
         onView(allOf(isAssignableFrom(TextView.class), withParent(isAssignableFrom(Toolbar.class))))
-                .check(matches(withText("Price per month")));
+                .check(matches(withText(navigationDrawerItemTitles[1])));
     }
 }

--- a/app/src/androidTest/java/com/huynd/skyobserver/fragments/PriceOneDayFragmentAndroidTest.java
+++ b/app/src/androidTest/java/com/huynd/skyobserver/fragments/PriceOneDayFragmentAndroidTest.java
@@ -158,6 +158,85 @@ public class PriceOneDayFragmentAndroidTest {
         Espresso.unregisterIdlingResources(mPriceOneDayFragmentIdlingResource);
     }
 
+    @Test
+    public void shouldLoadPricesWhenOpenFromChooseOneDayFragment() throws Exception {
+        onView(withContentDescription(mActivity.getString(R.string.drawer_open))).perform(click());
+        onData(anything()).inAdapterView(withId(R.id.listview_left_drawer)).atPosition(1).perform(click());
+
+        onView(withId(R.id.spinner_month_outbound)).perform(click());
+        onData(anything()).atPosition(2).perform(click());
+
+        onView(withId(R.id.chk_return_trip)).perform(click());
+        onView(withId(R.id.btn_find_flights)).perform(click());
+        checkViewWidgetsIsDisplayed(R.id.txt_routine_outbound, R.id.txt_flight_date_outbound,
+                R.id.chk_show_total_price_outbound, R.id.lst_prices_outbound);
+    }
+
+    @Test
+    public void testSortOrder() throws Exception {
+        onView(withContentDescription(mActivity.getString(R.string.drawer_open))).perform(click());
+        onData(anything()).inAdapterView(withId(R.id.listview_left_drawer)).atPosition(1).perform(click());
+        onView(withId(R.id.btn_find_flights)).perform(click());
+
+        onView(withId(R.id.menu_item_sort_order)).perform(click());
+        onView(withText(R.string.sorting_order_total_price_lowest)).perform(click());
+        onData(anything()).inAdapterView(withId(R.id.lst_prices_outbound)).atPosition(1)
+                .onChildView(withId(R.id.btn_select_price))
+                .check(matches(withText("1070")));
+
+        onView(withId(R.id.menu_item_sort_order)).perform(click());
+        onView(withText(R.string.sorting_order_total_price_highest)).perform(click());
+        onData(anything()).inAdapterView(withId(R.id.lst_prices_outbound)).atPosition(1)
+                .onChildView(withId(R.id.btn_select_price))
+                .check(matches(withText("1570")));
+
+        onView(withId(R.id.menu_item_sort_order)).perform(click());
+        onView(withText(R.string.sorting_order_depart_earliest)).perform(click());
+        onData(anything()).inAdapterView(withId(R.id.lst_prices_outbound)).atPosition(1)
+                .onChildView(withId(R.id.text_view_depart_time))
+                .check(matches(withText("15:00")));
+
+        onView(withId(R.id.menu_item_sort_order)).perform(click());
+        onView(withText(R.string.sorting_order_depart_latest)).perform(click());
+        onData(anything()).inAdapterView(withId(R.id.lst_prices_outbound)).atPosition(1)
+                .onChildView(withId(R.id.text_view_depart_time))
+                .check(matches(withText("17:00")));
+
+        onView(withId(R.id.menu_item_sort_order)).perform(click());
+        onView(withText(R.string.sorting_order_airlines)).perform(click());
+        onData(anything()).inAdapterView(withId(R.id.lst_prices_outbound)).atPosition(1)
+                .onChildView(withId(R.id.btn_select_price))
+                .check(matches(withText("1570")));
+        onData(anything()).inAdapterView(withId(R.id.lst_prices_outbound)).atPosition(1)
+                .onChildView(withId(R.id.text_view_depart_time))
+                .check(matches(withText("17:00")));
+    }
+
+    @Test
+    public void shouldDisplayPricesBeforeTax() throws Exception {
+        onView(withContentDescription(mActivity.getString(R.string.drawer_open))).perform(click());
+        onData(anything()).inAdapterView(withId(R.id.listview_left_drawer)).atPosition(1).perform(click());
+        onView(withId(R.id.btn_find_flights)).perform(click());
+        onView(withId(R.id.menu_item_sort_order)).perform(click());
+        onView(withText(R.string.sorting_order_total_price_lowest)).perform(click());
+
+        onData(anything()).inAdapterView(withId(R.id.lst_prices_outbound)).atPosition(0)
+                .onChildView(withId(R.id.btn_select_price))
+                .check(matches(withText("1070")));
+        onData(anything()).inAdapterView(withId(R.id.lst_prices_inbound)).atPosition(0)
+                .onChildView(withId(R.id.btn_select_price))
+                .check(matches(withText("1070")));
+
+        onView(withId(R.id.chk_show_total_price_outbound)).perform(click());
+        onView(withId(R.id.chk_show_total_price_inbound)).perform(click());
+        onData(anything()).inAdapterView(withId(R.id.lst_prices_outbound)).atPosition(0)
+                .onChildView(withId(R.id.btn_select_price))
+                .check(matches(withText("500")));
+        onData(anything()).inAdapterView(withId(R.id.lst_prices_inbound)).atPosition(0)
+                .onChildView(withId(R.id.btn_select_price))
+                .check(matches(withText("500")));
+    }
+
     private void checkViewWidgetsIsDisplayed(int... ids) {
         for (int id : ids) {
             onView(withId(id)).check(matches(isDisplayed()));
@@ -195,61 +274,5 @@ public class PriceOneDayFragmentAndroidTest {
 
         when(mPricesAPI.getPricePerDay(any(Map.class), any(PricePerDayBody.class), any(String.class),
                 any(String.class), any(String.class))).thenReturn(observableList);
-    }
-
-    @Test
-    public void shouldLoadPricesWhenOpenFromChooseOneDayFragment() throws Exception {
-        onView(withContentDescription(mActivity.getString(R.string.drawer_open))).perform(click());
-        onData(anything()).inAdapterView(withId(R.id.listview_left_drawer)).atPosition(1).perform(click());
-
-        onView(withId(R.id.spinner_month_outbound)).perform(click());
-        onData(anything()).atPosition(2).perform(click());
-
-        onView(withId(R.id.chk_return_trip)).perform(click());
-        onView(withId(R.id.btn_find_flights)).perform(click());
-        checkViewWidgetsIsDisplayed(R.id.txt_routine_outbound, R.id.txt_flight_date_outbound,
-                R.id.chk_show_total_price_outbound, R.id.lst_prices_outbound);
-    }
-
-    @Test
-    public void testSortOrder() throws Exception {
-        onView(withContentDescription(mActivity.getString(R.string.drawer_open))).perform(click());
-        onData(anything()).inAdapterView(withId(R.id.listview_left_drawer)).atPosition(1).perform(click());
-        onView(withId(R.id.spinner_month_outbound)).perform(click());
-        onData(anything()).atPosition(2).perform(click());
-        onView(withId(R.id.btn_find_flights)).perform(click());
-
-        onView(withId(R.id.menu_item_sort_order)).perform(click());
-        onView(withText(R.string.sorting_order_total_price_lowest)).perform(click());
-        onData(anything()).inAdapterView(withId(R.id.lst_prices_outbound)).atPosition(1)
-                .onChildView(withId(R.id.btn_select_price))
-                .check(matches(withText("1070")));
-
-        onView(withId(R.id.menu_item_sort_order)).perform(click());
-        onView(withText(R.string.sorting_order_total_price_highest)).perform(click());
-        onData(anything()).inAdapterView(withId(R.id.lst_prices_outbound)).atPosition(1)
-                .onChildView(withId(R.id.btn_select_price))
-                .check(matches(withText("1570")));
-
-        onView(withId(R.id.menu_item_sort_order)).perform(click());
-        onView(withText(R.string.sorting_order_depart_earliest)).perform(click());
-        onData(anything()).inAdapterView(withId(R.id.lst_prices_outbound)).atPosition(1)
-                .onChildView(withId(R.id.text_view_depart_time))
-                .check(matches(withText("15:00")));
-
-        onView(withId(R.id.menu_item_sort_order)).perform(click());
-        onView(withText(R.string.sorting_order_depart_latest)).perform(click());
-        onData(anything()).inAdapterView(withId(R.id.lst_prices_outbound)).atPosition(1)
-                .onChildView(withId(R.id.text_view_depart_time))
-                .check(matches(withText("17:00")));
-
-        onView(withId(R.id.menu_item_sort_order)).perform(click());
-        onView(withText(R.string.sorting_order_airlines)).perform(click());
-        onData(anything()).inAdapterView(withId(R.id.lst_prices_outbound)).atPosition(1)
-                .onChildView(withId(R.id.btn_select_price))
-                .check(matches(withText("1570")));
-        onData(anything()).inAdapterView(withId(R.id.lst_prices_outbound)).atPosition(1)
-                .onChildView(withId(R.id.text_view_depart_time))
-                .check(matches(withText("17:00")));
     }
 }

--- a/app/src/androidTest/java/com/huynd/skyobserver/fragments/PriceOneDayFragmentAndroidTest.java
+++ b/app/src/androidTest/java/com/huynd/skyobserver/fragments/PriceOneDayFragmentAndroidTest.java
@@ -178,6 +178,22 @@ public class PriceOneDayFragmentAndroidTest {
         onData(anything()).inAdapterView(withId(R.id.listview_left_drawer)).atPosition(1).perform(click());
         onView(withId(R.id.btn_find_flights)).perform(click());
 
+        onView(withId(R.id.chk_show_total_price_outbound)).perform(click());
+
+        onView(withId(R.id.menu_item_sort_order)).perform(click());
+        onView(withText(R.string.sorting_order_price_only_lowest)).perform(click());
+        onData(anything()).inAdapterView(withId(R.id.lst_prices_outbound)).atPosition(1)
+                .onChildView(withId(R.id.btn_select_price))
+                .check(matches(withText("500")));
+
+        onView(withId(R.id.menu_item_sort_order)).perform(click());
+        onView(withText(R.string.sorting_order_price_only_highest)).perform(click());
+        onData(anything()).inAdapterView(withId(R.id.lst_prices_outbound)).atPosition(1)
+                .onChildView(withId(R.id.btn_select_price))
+                .check(matches(withText("900")));
+
+        onView(withId(R.id.chk_show_total_price_outbound)).perform(click());
+
         onView(withId(R.id.menu_item_sort_order)).perform(click());
         onView(withText(R.string.sorting_order_total_price_lowest)).perform(click());
         onData(anything()).inAdapterView(withId(R.id.lst_prices_outbound)).atPosition(1)

--- a/app/src/main/java/com/huynd/skyobserver/adapters/ListViewPriceOneDayAdapter.java
+++ b/app/src/main/java/com/huynd/skyobserver/adapters/ListViewPriceOneDayAdapter.java
@@ -25,6 +25,7 @@ import static com.huynd.skyobserver.utils.Constants.CONVENIENCE_FEE_IN_K;
 
 public class ListViewPriceOneDayAdapter extends ArrayAdapter<PricePerDay> implements View.OnClickListener {
     private LayoutInflater mInflater;
+    private boolean mShouldShowTotalPrice;
 
     public ListViewPriceOneDayAdapter(Context context) {
         super(context, R.layout.list_view_price_one_day_item);
@@ -46,7 +47,6 @@ public class ListViewPriceOneDayAdapter extends ArrayAdapter<PricePerDay> implem
             btnSelect = (Button) view.findViewById(R.id.btn_select_price);
             ViewHolder viewHolder = new ViewHolder(imgvAirline, tvDepart, tvArrive, btnSelect);
             view.setTag(viewHolder);
-
         } else {
             ViewHolder viewHolder = (ViewHolder) view.getTag();
             imgvAirline = viewHolder.getImageViewAirline();
@@ -64,8 +64,10 @@ public class ListViewPriceOneDayAdapter extends ArrayAdapter<PricePerDay> implem
 
             tvDepart.setText(localDateFormat.format(item.getDepartureTime()));
             tvArrive.setText(localDateFormat.format(item.getArrivalTime()));
-            btnSelect.setText(String.valueOf(item.getPriceTotal() / 1000 + CONVENIENCE_FEE_IN_K));
             btnSelect.setOnClickListener(this);
+            int price = mShouldShowTotalPrice ?
+                    item.getPriceTotal() / 1000 + CONVENIENCE_FEE_IN_K : item.getPrice() / 1000;
+            btnSelect.setText(String.valueOf(price));
 
             Glide.with(getContext())
                     .load(RequestHelper.airlinesIconUrlBuilder(item.getCarrier()))
@@ -83,6 +85,10 @@ public class ListViewPriceOneDayAdapter extends ArrayAdapter<PricePerDay> implem
         // TODO
         // implement in another story
         // use BaseActivity.getCurrentFragment() to send message to PriceOneDay fragment
+    }
+
+    public void setShouldShowTotalPrice(boolean shouldShowTotalPrice) {
+        mShouldShowTotalPrice = shouldShowTotalPrice;
     }
 
     public static class ViewHolder {

--- a/app/src/main/java/com/huynd/skyobserver/fragments/PriceOneDayFragment.java
+++ b/app/src/main/java/com/huynd/skyobserver/fragments/PriceOneDayFragment.java
@@ -10,6 +10,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.CompoundButton;
 
 import com.huynd.skyobserver.R;
 import com.huynd.skyobserver.SkyObserverApp;
@@ -30,7 +31,10 @@ import javax.inject.Inject;
  * Created by HuyND on 8/14/2017.
  */
 
-public class PriceOneDayFragment extends BaseFragment implements PriceOneDayView {
+public class PriceOneDayFragment extends BaseFragment implements
+        PriceOneDayView,
+        CompoundButton.OnCheckedChangeListener {
+
     @Inject
     PricesAPI mPricesAPI;
 
@@ -81,16 +85,20 @@ public class PriceOneDayFragment extends BaseFragment implements PriceOneDayView
         mBinding.txtRoutineOutbound.setText(srcPort + " - " + dstPort);
         mBinding.txtFlightDateOutbound.setText(dayOutbound + "/" + monthOutbound + "/" + yearOutbound);
         mListViewOutboundAdapter = new ListViewPriceOneDayAdapter(this.getContext());
+        mListViewOutboundAdapter.setShouldShowTotalPrice(mBinding.chkShowTotalPriceOutbound.isChecked());
         mBinding.lstPricesOutbound.setAdapter(mListViewOutboundAdapter);
         if (returnTrip) {
             mBinding.layoutInbound.setVisibility(View.VISIBLE);
             mBinding.txtRoutineInbound.setText(dstPort + " - " + srcPort);
             mBinding.txtFlightDateInbound.setText(dayInbound + "/" + monthInbound + "/" + yearInbound);
             mListViewInboundAdapter = new ListViewPriceOneDayAdapter(this.getContext());
+            mListViewInboundAdapter.setShouldShowTotalPrice(mBinding.chkShowTotalPriceInbound.isChecked());
             mBinding.lstPricesInbound.setAdapter(mListViewInboundAdapter);
+            mBinding.chkShowTotalPriceInbound.setOnCheckedChangeListener(this);
         } else {
             mBinding.layoutInbound.setVisibility(View.GONE);
         }
+        mBinding.chkShowTotalPriceOutbound.setOnCheckedChangeListener(this);
 
         // initialize MPV pattern
         mPresenter = new PriceOneDayPresenterImpl(this, mPricesAPI);
@@ -154,5 +162,19 @@ public class PriceOneDayFragment extends BaseFragment implements PriceOneDayView
     @Override
     public void showInvalidDateDialog() {
         showFailedDialog(getString(R.string.invalid_date_message));
+    }
+
+    @Override
+    public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+        switch (buttonView.getId()) {
+            case R.id.chk_show_total_price_outbound:
+                mListViewOutboundAdapter.setShouldShowTotalPrice(mBinding.chkShowTotalPriceOutbound.isChecked());
+                mListViewOutboundAdapter.notifyDataSetChanged();
+                break;
+            case R.id.chk_show_total_price_inbound:
+                mListViewInboundAdapter.setShouldShowTotalPrice(mBinding.chkShowTotalPriceInbound.isChecked());
+                mListViewInboundAdapter.notifyDataSetChanged();
+                break;
+        }
     }
 }

--- a/app/src/main/java/com/huynd/skyobserver/fragments/PriceOneDayFragment.java
+++ b/app/src/main/java/com/huynd/skyobserver/fragments/PriceOneDayFragment.java
@@ -123,6 +123,12 @@ public class PriceOneDayFragment extends BaseFragment implements
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
+            case R.id.sorting_order_price_only_lowest:
+                mPresenter.setSortOrder(PriceComparator.SortOrder.PRICE_ONLY_LOWEST);
+                break;
+            case R.id.sorting_order_price_only_highest:
+                mPresenter.setSortOrder(PriceComparator.SortOrder.PRICE_ONLY_HIGHEST);
+                break;
             case R.id.sorting_order_total_price_lowest:
                 mPresenter.setSortOrder(PriceComparator.SortOrder.TOTAL_PRICE_LOWEST);
                 break;

--- a/app/src/main/java/com/huynd/skyobserver/utils/PriceComparator.java
+++ b/app/src/main/java/com/huynd/skyobserver/utils/PriceComparator.java
@@ -13,6 +13,8 @@ import static com.huynd.skyobserver.utils.PriceComparator.SortOrder.DEPART_EARLI
 public class PriceComparator implements Comparator<PricePerDay> {
 
     public enum SortOrder {
+        PRICE_ONLY_LOWEST,
+        PRICE_ONLY_HIGHEST,
         TOTAL_PRICE_LOWEST,
         TOTAL_PRICE_HIGHEST,
         DEPART_EARLIEST,
@@ -47,6 +49,10 @@ public class PriceComparator implements Comparator<PricePerDay> {
         }
 
         switch (mOrder) {
+            case PRICE_ONLY_LOWEST:
+                return price1.getPrice() - price2.getPrice();
+            case PRICE_ONLY_HIGHEST:
+                return price2.getPrice() - price1.getPrice();
             case TOTAL_PRICE_LOWEST:
                 return price1.getPriceTotal() - price2.getPriceTotal();
             case TOTAL_PRICE_HIGHEST:

--- a/app/src/main/res/menu/fragment_price_one_day.xml
+++ b/app/src/main/res/menu/fragment_price_one_day.xml
@@ -8,6 +8,12 @@
         app:showAsAction="ifRoom">
         <menu>
             <item
+                android:id="@+id/sorting_order_price_only_lowest"
+                android:title="@string/sorting_order_price_only_lowest" />
+            <item
+                android:id="@+id/sorting_order_price_only_highest"
+                android:title="@string/sorting_order_price_only_highest" />
+            <item
                 android:id="@+id/sorting_order_total_price_lowest"
                 android:title="@string/sorting_order_total_price_lowest" />
             <item

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -18,6 +18,8 @@
     <string name="return_trip">Khứ hồi</string>
 
     <string name="sorting_order">Thứ tự sắp xếp</string>
+    <string name="sorting_order_price_only_lowest">Giá trước thuế: Thấp đến cao</string>
+    <string name="sorting_order_price_only_highest">Giá trước thuế: Cao đến thấp</string>
     <string name="sorting_order_total_price_lowest">Giá sau thuế: Thấp đến cao</string>
     <string name="sorting_order_total_price_highest">Giá sau thuế: Cao đến thấp</string>
     <string name="sorting_order_depart_earliest">Giờ bay: sớm nhất</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,8 @@
     <string name="return_trip">Return trip</string>
 
     <string name="sorting_order">Sorting Order</string>
+    <string name="sorting_order_price_only_lowest">Price Only: Lowest first</string>
+    <string name="sorting_order_price_only_highest">Price Only: Highest first</string>
     <string name="sorting_order_total_price_lowest">Total Price: Lowest first</string>
     <string name="sorting_order_total_price_highest">Total Price: Highest first</string>
     <string name="sorting_order_depart_earliest">Depart: Earliest first</string>


### PR DESCRIPTION
- Display prices after/before tax when user checks/unchecks the corresponding checkboxes.
- Add menu items to sort by prices before taxes and fees.
- Add more test cases to cover newly-introduced code.
- Keep code coverage high: 99.9%