### PR TITLE
Story 04 - Fix - App crash when user navigates to Home Screen then go back

### DIFF
--- a/app/src/androidTest/java/com/huynd/skyobserver/activities/BaseActivityAndroidTest.java
+++ b/app/src/androidTest/java/com/huynd/skyobserver/activities/BaseActivityAndroidTest.java
@@ -5,6 +5,8 @@ import android.support.test.espresso.Espresso;
 import android.support.test.espresso.NoActivityResumedException;
 import android.support.test.rule.ActivityTestRule;
 import android.support.v4.app.Fragment;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.app.AppCompatDelegate;
 
 import com.huynd.skyobserver.fragments.PriceOneDayFragment;
 import com.huynd.skyobserver.fragments.PricePerDayFragment;
@@ -14,9 +16,14 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.lang.reflect.Field;
+
 import static android.support.test.espresso.Espresso.pressBack;
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by HuyND on 8/19/2017.
@@ -76,5 +83,17 @@ public class BaseActivityAndroidTest {
 
         mActivity.setFragment(pricePerDayFragment, PricePerDayFragment.TAG, false);
         assertTrue(mActivity.getCurrentFragment() instanceof PricePerDayFragment);
+    }
+
+    @Test
+    public void shouldHandleOnStartException() throws Exception {
+        AppCompatActivity spyActivity = spy(mActivity);
+        when(spyActivity.getDelegate()).thenThrow(new NullPointerException());
+
+        try {
+            mActivity.onStart();
+        } catch (NullPointerException nullPointerException) {
+            fail("Exception should be caught.");
+        }
     }
 }

--- a/app/src/androidTest/java/com/huynd/skyobserver/fragments/PricePerDayFragmentAndroidTest.java
+++ b/app/src/androidTest/java/com/huynd/skyobserver/fragments/PricePerDayFragmentAndroidTest.java
@@ -132,7 +132,7 @@ public class PricePerDayFragmentAndroidTest {
         fragment.mSpinnerYearAdapter = adapter;
 
         try {
-            onData(anything()).inAdapterView(withId(R.id.grid_view_price)).atPosition(3).perform(click());
+            onData(anything()).inAdapterView(withId(R.id.grid_view_price)).atPosition(5).perform(click());
         } catch (Exception exception) {
             fail("Unexpected behavior happened.");
         }

--- a/app/src/main/java/com/huynd/skyobserver/activities/BaseActivity.java
+++ b/app/src/main/java/com/huynd/skyobserver/activities/BaseActivity.java
@@ -20,6 +20,15 @@ public class BaseActivity extends AppCompatActivity {
     String mCurrentFragmentTag;
 
     @Override
+    protected void onStart() {
+        try {
+            super.onStart();
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         fragmentManager = getSupportFragmentManager();


### PR DESCRIPTION
- A workaround to fix the bug causes app crashes when user press Home button to navigate to Home Screen then go back to the app.
- Test to cover new code.