### PR TITLE
Chore 08 - Update Gradle and libraries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ references:
   android_config: &android_config
     working_directory: *workspace
     docker:
-      - image: circleci/android:api-27-alpha
+      - image: circleci/android:api-28-alpha
     environment:
       TERM: dumb
       _JAVA_OPTIONS: "-Xmx2048m -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
@@ -172,8 +172,8 @@ jobs:
           command: |
             gcloud firebase test android run \
               --type instrumentation \
-              --app app/build/outputs/apk/app-debug.apk \
-              --test app/build/outputs/apk/app-debug-androidTest.apk \
+              --app app/build/outputs/apk/debug/app-debug.apk \
+              --test app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk \
               --device model=Nexus4,version=22,locale=en_US,orientation=portrait \
               --environment-variables coverage=true,coverageFile=/sdcard/coverage.ec \
               --directories-to-pull /sdcard --timeout 20m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,7 +174,7 @@ jobs:
               --type instrumentation \
               --app app/build/outputs/apk/debug/app-debug.apk \
               --test app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk \
-              --device model=Nexus4,version=22,locale=en_US,orientation=portrait \
+              --device model=Nexus6,version=23,locale=en_US,orientation=portrait \
               --environment-variables coverage=true,coverageFile=/sdcard/coverage.ec \
               --directories-to-pull /sdcard --timeout 20m
       - run:
@@ -204,7 +204,7 @@ jobs:
       - *attach_firebase_workspace
       - run:
           name: Move Firebase coverage report
-          command: mkdir -p app/build/outputs/code-coverage/connected && cp firebase/Nexus4-22-en_US-portrait/artifacts/coverage.ec app/build/outputs/code-coverage/connected/coverage.ec
+          command: mkdir -p app/build/outputs/code-coverage/connected && cp firebase/Nexus6-23-en_US-portrait/artifacts/coverage.ec app/build/outputs/code-coverage/connected/coverage.ec
       - *export_gservices_key
       - *decode_gservices_key
       - run:

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -3,6 +3,9 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <compositeConfiguration>
+          <compositeBuild compositeDefinitionSource="SCRIPT" />
+        </compositeConfiguration>
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'jacoco'
 apply plugin: 'com.github.kt3k.coveralls'
-apply plugin: 'com.neenbedankt.android-apt'
 
 
 def Properties properties = new Properties()
@@ -121,9 +120,7 @@ dependencies {
     testCompile "org.robolectric:shadows-support-v4:3.1.4"
 
     // dagger
-    apt 'com.google.dagger:dagger-compiler:2.0'
-    testApt "com.google.dagger:dagger-compiler:2.0"
-    androidTestApt "com.google.dagger:dagger-compiler:2.0"
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.0'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 }
 
@@ -135,9 +132,6 @@ task jacocoTestReport(type: JacocoReport) {
         xml.enabled = true
         html.enabled = true
     }
-
-    // use hidden configuration, for details look into JacocoPlugin.groovy
-    jacocoClasspath = project.configurations['androidJacocoAnt']
 
     // exclude auto-generated classes and tests
     def fileFilter = ['**/R.class',

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,6 +53,9 @@ android {
     }
 
     testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
         unitTests.all {
             jacoco {
                 includeNoLocationClasses = true
@@ -121,7 +124,8 @@ dependencies {
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.18.3'
-    testImplementation 'org.robolectric:shadows-support-v4:3.3.2'
+    testImplementation 'org.robolectric:robolectric:4.2'
+    testImplementation 'org.robolectric:shadows-support-v4:3.4-rc2'
 }
 
 task jacocoTestReport(type: JacocoReport) {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,8 @@
-apply plugin: 'com.android.application'
-apply plugin: 'jacoco'
-apply plugin: 'com.github.kt3k.coveralls'
-
+plugins {
+    id 'com.android.application'
+    id 'jacoco'
+    id 'com.github.kt3k.coveralls'
+}
 
 def Properties properties = new Properties()
 properties.load(project.rootProject.file("local.properties").newDataInputStream())
@@ -65,19 +66,22 @@ jacoco {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:28.0.0'
-    compile 'com.android.support:support-v4:28.0.0'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:support-v4:28.0.0'
 
-    compile 'com.github.twinkle942910:monthyearpicker:0.0.1'
+    implementation 'com.github.twinkle942910:monthyearpicker:0.0.1'
 
     // dagger
-    compile 'com.google.dagger:dagger:2.0'
+    implementation 'com.google.dagger:dagger:2.17'
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.17'
+    androidTestAnnotationProcessor 'com.google.dagger:dagger-compiler:2.17'
+    compileOnly 'org.glassfish:javax.annotation:10.0-b28'
 
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    androidTestCompile('com.android.support.test.espresso:espresso-contrib:2.2.2') {
+    androidTestImplementation('com.android.support.test.espresso:espresso-contrib:2.2.2') {
         exclude module: 'espresso-core'
         exclude module: 'support-v4'
         exclude module: 'recyclerview-v7'
@@ -87,41 +91,37 @@ dependencies {
     }
 
     // Retrofit
-    compile 'com.google.code.gson:gson:2.6.2'
-    compile 'com.squareup.retrofit2:retrofit:2.3.0'
-    compile 'com.squareup.retrofit2:converter-gson:2.3.0'
-    compile 'com.squareup.retrofit2:adapter-rxjava2:2.3.0'
-    compile 'com.squareup.okhttp3:okhttp:3.6.0'
-    compile 'com.squareup.okhttp3:logging-interceptor:3.6.0'
+    implementation 'com.google.code.gson:gson:2.6.2'
+    implementation 'com.squareup.retrofit2:retrofit:2.3.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.3.0'
+    implementation 'com.squareup.retrofit2:adapter-rxjava2:2.3.0'
+    implementation 'com.squareup.okhttp3:okhttp:3.6.0'
+    implementation 'com.squareup.okhttp3:logging-interceptor:3.6.0'
 
-    //RxAndroid
-    compile 'io.reactivex.rxjava2:rxandroid:2.0.1'
-    compile 'io.reactivex.rxjava2:rxjava:2.1.3'
+    // RxAndroid
+    implementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
+    implementation 'io.reactivex.rxjava2:rxjava:2.1.3'
 
     // RxBinding
-    compile 'com.jakewharton.rxbinding2:rxbinding:2.0.0'
-    compile 'com.jakewharton.rxbinding2:rxbinding-support-v4:2.0.0'
-    compile 'com.jakewharton.rxbinding2:rxbinding-appcompat-v7:2.0.0'
+    implementation 'com.jakewharton.rxbinding2:rxbinding:2.0.0'
+    implementation 'com.jakewharton.rxbinding2:rxbinding-support-v4:2.0.0'
+    implementation 'com.jakewharton.rxbinding2:rxbinding-appcompat-v7:2.0.0'
 
     // Glide
-    compile 'com.github.bumptech.glide:glide:3.6.1'
+    implementation 'com.github.bumptech.glide:glide:3.6.1'
 
     // hockeyapp
     //compile 'net.hockeyapp.android:HockeySDK:5.0.1'
 
     // mockito
-    androidTestCompile "org.mockito:mockito-core:2.0.5-beta"
-    androidTestCompile "com.crittercism.dexmaker:dexmaker:1.4"
-    androidTestCompile "com.crittercism.dexmaker:dexmaker-dx:1.4"
-    androidTestCompile "com.crittercism.dexmaker:dexmaker-mockito:1.4"
+    androidTestImplementation 'org.mockito:mockito-core:2.0.5-beta'
+    androidTestImplementation 'com.crittercism.dexmaker:dexmaker:1.4'
+    androidTestImplementation 'com.crittercism.dexmaker:dexmaker-dx:1.4'
+    androidTestImplementation 'com.crittercism.dexmaker:dexmaker-mockito:1.4'
 
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:1.10.19'
-    testCompile "org.robolectric:shadows-support-v4:3.1.4"
-
-    // dagger
-    annotationProcessor 'com.google.dagger:dagger-compiler:2.0'
-    provided 'org.glassfish:javax.annotation:10.0-b28'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:1.10.19'
+    testImplementation 'org.robolectric:shadows-support-v4:3.1.4'
 }
 
 task jacocoTestReport(type: JacocoReport) {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -117,13 +117,11 @@ dependencies {
     //compile 'net.hockeyapp.android:HockeySDK:5.0.1'
 
     // mockito
-    androidTestImplementation 'org.mockito:mockito-core:2.18.3'
-    androidTestImplementation 'com.crittercism.dexmaker:dexmaker:1.4'
-    androidTestImplementation 'com.crittercism.dexmaker:dexmaker-dx:1.4'
-    androidTestImplementation 'com.crittercism.dexmaker:dexmaker-mockito:1.4'
+    androidTestImplementation 'org.mockito:mockito-core:2.25.0'
+    androidTestImplementation 'com.linkedin.dexmaker:dexmaker-mockito:2.25.0'
 
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.18.3'
+    testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation 'org.robolectric:robolectric:4.2'
     testImplementation 'org.robolectric:shadows-support-v4:3.4-rc2'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,12 +7,12 @@ def Properties properties = new Properties()
 properties.load(project.rootProject.file("local.properties").newDataInputStream())
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
     defaultConfig {
         applicationId "com.huynd.skyobserver"
-        minSdkVersion 17
-        targetSdkVersion 27
+        minSdkVersion 23
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "com.huynd.skyobserver.AndroidTestRunner"
@@ -66,8 +66,8 @@ jacoco {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:27.1.1'
-    compile 'com.android.support:support-v4:27.1.1'
+    compile 'com.android.support:appcompat-v7:28.0.0'
+    compile 'com.android.support:support-v4:28.0.0'
 
     compile 'com.github.twinkle942910:monthyearpicker:0.0.1'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -151,7 +151,7 @@ task jacocoTestReport(type: JacocoReport) {
                       '**/*MembersInjector*.*',
                       '**/*DaggerApplicationComponent*.class',
                       'com/huynd/skyobserver/dagger/**/*.*']
-    def debugTree = fileTree(dir: "${project.buildDir}/intermediates/classes/debug", excludes: fileFilter)
+    def debugTree = fileTree(dir: "${project.buildDir}/intermediates/javac/debug", excludes: fileFilter)
     def mainSrc = "${project.projectDir}/src/main/java"
 
     sourceDirectories = files([mainSrc])

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,7 +62,7 @@ android {
 }
 
 jacoco {
-    toolVersion "0.7.6.201602180812"
+    toolVersion "0.8.1"
 }
 
 dependencies {
@@ -91,12 +91,12 @@ dependencies {
     }
 
     // Retrofit
-    implementation 'com.google.code.gson:gson:2.6.2'
-    implementation 'com.squareup.retrofit2:retrofit:2.3.0'
+    implementation 'com.google.code.gson:gson:2.8.2'
+    implementation 'com.squareup.retrofit2:retrofit:2.4.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.3.0'
     implementation 'com.squareup.retrofit2:adapter-rxjava2:2.3.0'
-    implementation 'com.squareup.okhttp3:okhttp:3.6.0'
-    implementation 'com.squareup.okhttp3:logging-interceptor:3.6.0'
+    implementation 'com.squareup.okhttp3:okhttp:3.10.0'
+    implementation 'com.squareup.okhttp3:logging-interceptor:3.8.0'
 
     // RxAndroid
     implementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
@@ -108,20 +108,20 @@ dependencies {
     implementation 'com.jakewharton.rxbinding2:rxbinding-appcompat-v7:2.0.0'
 
     // Glide
-    implementation 'com.github.bumptech.glide:glide:3.6.1'
+    implementation 'com.github.bumptech.glide:glide:4.7.1'
 
     // hockeyapp
     //compile 'net.hockeyapp.android:HockeySDK:5.0.1'
 
     // mockito
-    androidTestImplementation 'org.mockito:mockito-core:2.0.5-beta'
+    androidTestImplementation 'org.mockito:mockito-core:2.18.3'
     androidTestImplementation 'com.crittercism.dexmaker:dexmaker:1.4'
     androidTestImplementation 'com.crittercism.dexmaker:dexmaker-dx:1.4'
     androidTestImplementation 'com.crittercism.dexmaker:dexmaker-mockito:1.4'
 
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:1.10.19'
-    testImplementation 'org.robolectric:shadows-support-v4:3.1.4'
+    testImplementation 'org.mockito:mockito-core:2.18.3'
+    testImplementation 'org.robolectric:shadows-support-v4:3.3.2'
 }
 
 task jacocoTestReport(type: JacocoReport) {

--- a/app/src/main/java/com/huynd/skyobserver/adapters/GridViewPricePerDayAdapter.java
+++ b/app/src/main/java/com/huynd/skyobserver/adapters/GridViewPricePerDayAdapter.java
@@ -60,10 +60,10 @@ public class GridViewPricePerDayAdapter extends ArrayAdapter<PricePerDay> {
                         .load(RequestHelper.airlinesIconUrlBuilder(carrier))
                         .into(imgvAirline);
             } else {
-                Glide.clear(imgvAirline);
+                Glide.with(getContext()).clear(imgvAirline);
             }
         } else {
-            Glide.clear(imgvAirline);
+            Glide.with(getContext()).clear(imgvAirline);
             textViewDay.setText("");
             textViewPrice.setText("");
         }

--- a/app/src/main/java/com/huynd/skyobserver/adapters/NavigationDrawerListAdapter.java
+++ b/app/src/main/java/com/huynd/skyobserver/adapters/NavigationDrawerListAdapter.java
@@ -5,7 +5,7 @@ import android.support.annotation.LayoutRes;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
 
-import com.android.annotations.NonNull;
+import android.support.annotation.NonNull;
 
 /**
  * Created by HuyND on 8/5/2017.

--- a/app/src/test/java/com/huynd/skyobserver/PriceOneDayViewTest.java
+++ b/app/src/test/java/com/huynd/skyobserver/PriceOneDayViewTest.java
@@ -10,9 +10,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
-import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static junit.framework.Assert.fail;
 
 /**
@@ -20,7 +18,6 @@ import static junit.framework.Assert.fail;
  */
 
 @RunWith(RobolectricTestRunner.class)
-@Config(constants = BuildConfig.class, sdk = LOLLIPOP)
 public class PriceOneDayViewTest {
     private MainActivity mActivity;
 

--- a/app/src/test/java/com/huynd/skyobserver/activities/MainActivityTest.java
+++ b/app/src/test/java/com/huynd/skyobserver/activities/MainActivityTest.java
@@ -1,14 +1,11 @@
 package com.huynd.skyobserver.activities;
 
-import com.huynd.skyobserver.BuildConfig;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
-import static android.os.Build.VERSION_CODES.LOLLIPOP;
+
 import static junit.framework.Assert.fail;
 
 /**
@@ -16,7 +13,6 @@ import static junit.framework.Assert.fail;
  */
 
 @RunWith(RobolectricTestRunner.class)
-@Config(constants = BuildConfig.class, sdk = LOLLIPOP)
 public class MainActivityTest {
     private MainActivity mActivity;
 

--- a/app/src/test/java/com/huynd/skyobserver/adapters/ListViewPriceOneDayAdapterTest.java
+++ b/app/src/test/java/com/huynd/skyobserver/adapters/ListViewPriceOneDayAdapterTest.java
@@ -2,7 +2,6 @@ package com.huynd.skyobserver.adapters;
 
 import android.view.View;
 
-import com.huynd.skyobserver.BuildConfig;
 import com.huynd.skyobserver.activities.MainActivity;
 
 import org.junit.Before;
@@ -10,9 +9,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
-import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static junit.framework.Assert.assertEquals;
 
 /**
@@ -20,7 +17,6 @@ import static junit.framework.Assert.assertEquals;
  */
 
 @RunWith(RobolectricTestRunner.class)
-@Config(constants = BuildConfig.class, sdk = LOLLIPOP)
 public class ListViewPriceOneDayAdapterTest {
     private MainActivity mActivity;
 

--- a/app/src/test/java/com/huynd/skyobserver/utils/FlowUtilsTest.java
+++ b/app/src/test/java/com/huynd/skyobserver/utils/FlowUtilsTest.java
@@ -2,7 +2,6 @@ package com.huynd.skyobserver.utils;
 
 import android.app.ProgressDialog;
 
-import com.huynd.skyobserver.BuildConfig;
 import com.huynd.skyobserver.activities.MainActivity;
 
 import org.junit.Before;
@@ -10,9 +9,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
-import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static junit.framework.Assert.fail;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
@@ -22,7 +19,6 @@ import static org.mockito.Mockito.spy;
  */
 
 @RunWith(RobolectricTestRunner.class)
-@Config(constants = BuildConfig.class, sdk = LOLLIPOP)
 public class FlowUtilsTest {
     private MainActivity mMainActivity;
     private FlowUtils mFlowUtils;

--- a/app/src/test/resources/com/huynd/skyobserver/robolectric.properties
+++ b/app/src/test/resources/com/huynd/skyobserver/robolectric.properties
@@ -1,0 +1,2 @@
+constants=com.huynd.skyobserver.BuildConfig
+sdk=23

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.4.0x'
+        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.6.3'
         classpath 'com.android.tools.build:gradle:3.4.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,13 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.4.0x'
+        classpath 'com.android.tools.build:gradle:3.4.1'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -16,10 +18,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
-        }
+        google()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ buildscript {
     dependencies {
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.4.0x'
         classpath 'com.android.tools.build:gradle:3.4.1'
-        classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
-
+android.enableUnitTestBinaryResources=true
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
- Update to:
  - Gradle wrapper 5.1.1
  - Android Gradle plugin 3.4.1
  - JaCoCo 0.8.1
  - Config Robolectric 4 with AGP 3+
  - Other libraries to their latest versions
- Set compileSdkVersion and targetSdkVersion to 28 (Android 9) and minSdkVersion to 23 (Android 6)
  - Use docker image `android:api-28-alpha` on CircleCI
  - Use device `Nexus6,version=23` for running instrumental tests on Firebase Testlab